### PR TITLE
Fix warning message and add fan on capability for climate.py

### DIFF
--- a/custom_components/vivint/climate.py
+++ b/custom_components/vivint/climate.py
@@ -71,6 +71,7 @@ VIVINT_CAPABILITY_FAN_MODE_MAP = {
 
 VIVINT_FAN_MODE_MAP = {
     FanMode.AUTO_LOW: FAN_AUTO,
+    FanMode.ON_LOW: FAN_ON,
     FanMode.TIMER_15: "15 minutes",
     FanMode.TIMER_30: "30 minutes",
     FanMode.TIMER_45: "45 minutes",

--- a/custom_components/vivint/climate.py
+++ b/custom_components/vivint/climate.py
@@ -122,10 +122,10 @@ class VivintClimate(VivintEntity, ClimateEntity):
     _enable_turn_on_off_backwards_compatibility = False
     _attr_supported_features = (
         ClimateEntityFeature.TARGET_TEMPERATURE
-        | ClimateEntityFeature.TURN_OFF
-        | ClimateEntityFeature.TURN_ON
         | ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
         | ClimateEntityFeature.FAN_MODE
+        | ClimateEntityFeature.TURN_OFF
+        | ClimateEntityFeature.TURN_ON
     )
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
 

--- a/custom_components/vivint/climate.py
+++ b/custom_components/vivint/climate.py
@@ -118,8 +118,11 @@ class VivintClimate(VivintEntity, ClimateEntity):
     device: Thermostat
 
     _attr_hvac_modes = [HVACMode.COOL, HVACMode.HEAT, HVACMode.HEAT_COOL, HVACMode.OFF]
+    _enable_turn_on_off_backwards_compatibility = False
     _attr_supported_features = (
         ClimateEntityFeature.TARGET_TEMPERATURE
+        | ClimateEntityFeature.TURN_OFF
+        | ClimateEntityFeature.TURN_ON
         | ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
         | ClimateEntityFeature.FAN_MODE
     )
@@ -208,6 +211,14 @@ class VivintClimate(VivintEntity, ClimateEntity):
                 )
             }
         )
+
+    async def async_turn_off(self) -> None:
+        """Turn off fan."""
+        await self.async_set_hvac_mode(HVACMode.OFF)
+
+    async def async_turn_on(self) -> None:
+        """Turn on fan."""
+        await self.async_set_hvac_mode(HVACMode.HEATING)
 
     async def async_set_hvac_mode(self, hvac_mode: str) -> None:
         """Set new target hvac mode."""


### PR DESCRIPTION
Fix warning message for implicitly supporting turn_on/off methods in HVACModes
Fixes:
Entity None (<class 'custom_components.vivint.climate.VivintClimate'>) implements HVACMode(s): cool, heat, heat_cool, off and therefore implicitly supports the turn_on/turn_off methods without setting the proper ClimateEntityFeature. Please create a bug report at https://github.com/natekspencer/hacs-vivint/issues

Fix missing fan mode on
Fan mode does not turn on if selected, as it is missing in the Vivint fan mode map.