### PR TITLE
Fix warning message for implicitly supporting turn_on/off methods in HVACModes

### DIFF
--- a/custom_components/vivint/climate.py
+++ b/custom_components/vivint/climate.py
@@ -125,8 +125,8 @@ class VivintClimate(VivintEntity, ClimateEntity):
         | ClimateEntityFeature.TURN_ON
         | ClimateEntityFeature.TURN_OFF
     )
-    _enable_turn_on_off_backwards_compatibility = False
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
+    _enable_turn_on_off_backwards_compatibility = False
 
     def __init__(self, device: Thermostat, hub: VivintHub) -> None:
         """Pass coordinator to CoordinatorEntity."""
@@ -211,7 +211,6 @@ class VivintClimate(VivintEntity, ClimateEntity):
                 )
             }
         )
-
 
     async def async_set_hvac_mode(self, hvac_mode: str) -> None:
         """Set new target hvac mode."""

--- a/custom_components/vivint/climate.py
+++ b/custom_components/vivint/climate.py
@@ -122,7 +122,10 @@ class VivintClimate(VivintEntity, ClimateEntity):
         ClimateEntityFeature.TARGET_TEMPERATURE
         | ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
         | ClimateEntityFeature.FAN_MODE
+        | ClimateEntityFeature.TURN_ON
+        | ClimateEntityFeature.TURN_OFF
     )
+    _enable_turn_on_off_backwards_compatibility = False
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
 
     def __init__(self, device: Thermostat, hub: VivintHub) -> None:
@@ -209,11 +212,20 @@ class VivintClimate(VivintEntity, ClimateEntity):
             }
         )
 
+
     async def async_set_hvac_mode(self, hvac_mode: str) -> None:
         """Set new target hvac mode."""
         await self.device.set_state(
             **{ThermostatAttribute.OPERATING_MODE: VIVINT_HVAC_INV_MODE_MAP[hvac_mode]}
         )
+
+    async def async_turn_on(self) -> None:
+        """Turn the entity on."""
+        await self.async_set_hvac_mode(HVACMode.HEAT_COOL)
+
+    async def async_turn_off(self) -> None:
+        """Turn the entity off."""
+        await self.async_set_hvac_mode(HVACMode.OFF)
 
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""


### PR DESCRIPTION
Closes #161: Warning message:

Entity None (<class 'custom_components.vivint.climate.VivintClimate'>) implements HVACMode(s): cool, heat, heat_cool, off and therefore implicitly supports the turn_on/turn_off methods without setting the proper ClimateEntityFeature. Please create a bug report at https://github.com/natekspencer/hacs-vivint/issues