### PR TITLE
Clarify username is email

### DIFF
--- a/custom_components/vivint/translations/en.json
+++ b/custom_components/vivint/translations/en.json
@@ -3,7 +3,7 @@
     "step": {
       "user": {
         "data": {
-          "username": "Username",
+          "username": "Login Email",
           "password": "Password"
         }
       },
@@ -16,7 +16,7 @@
       "reauth_confirm": {
         "description": "Reauthenticate Integration",
         "data": {
-          "username": "Username",
+          "username": "Login Email",
           "password": "Password"
         }
       }


### PR DESCRIPTION
Whenever first setting up, or reauthenticating for the first time in awhile, being prompted for a "Username" doesn't clarify that it must be an email. A small change to the prompt here to say "Login Email" can make a helpful difference without requiring changes elsewhere.

![Screenshot_20250118_135342_Home Assistant](https://github.com/user-attachments/assets/f1b13cf3-0da9-4116-b41b-6216c053a09f)
