### PR TITLE
Fix color_mode assignment

### DIFF
--- a/custom_components/vivint/light.py
+++ b/custom_components/vivint/light.py
@@ -38,7 +38,7 @@ class VivintLightEntity(VivintEntity, LightEntity):
 
     device: MultilevelSwitch
 
-    _attr_color_mode: ColorMode.BRIGHTNESS
+    _attr_color_mode = ColorMode.BRIGHTNESS
     _attr_supported_color_modes = {ColorMode.BRIGHTNESS}
 
     @property


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed color mode initialization for Vivint light devices in Home Assistant. The brightness mode setting is now properly configured and exposed to the platform, ensuring your Vivint lights are correctly recognized and fully functional with all Home Assistant controls and automations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->