### PR TITLE
Bump minimum HA version

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,6 @@
 {
   "name": "Vivint",
-  "homeassistant": "2024.11.0",
+  "homeassistant": "2026.6.0",
   "render_readme": true,
   "zip_release": true,
   "filename": "vivint.zip"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Home Assistant
-homeassistant>=2025.5.0
+homeassistant>=2026.6.0
 
 # Integration
 vivintpy


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated minimum required Home Assistant version to 2026.6.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->