### PR TITLE
Hide disarm code input in options flow

### DIFF
--- a/custom_components/vivint/config_flow.py
+++ b/custom_components/vivint/config_flow.py
@@ -25,6 +25,11 @@ from homeassistant.helpers.schema_config_entry_flow import (
     SchemaFlowFormStep,
     SchemaOptionsFlowHandler,
 )
+from homeassistant.helpers.selector import (
+    TextSelector,
+    TextSelectorConfig,
+    TextSelectorType,
+)
 
 from .const import (
     CONF_DISARM_CODE,
@@ -62,7 +67,9 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
 STEP_MFA_DATA_SCHEMA = vol.Schema({vol.Required(CONF_MFA): str})
 OPTIONS_SCHEMA = vol.Schema(
     {
-        vol.Optional(CONF_DISARM_CODE, default=""): str,
+        vol.Optional(CONF_DISARM_CODE, default=""): TextSelector(
+            TextSelectorConfig(type=TextSelectorType.PASSWORD)
+        ),
         vol.Optional(CONF_HD_STREAM, default=DEFAULT_HD_STREAM): bool,
         vol.Optional(CONF_RTSP_STREAM, default=DEFAULT_RTSP_STREAM): vol.In(
             RTSP_STREAM_TYPES

--- a/custom_components/vivint/strings.json
+++ b/custom_components/vivint/strings.json
@@ -46,7 +46,7 @@
       }
     },
     "error": {
-      "disarm_code_invalid": "Disarm code is invalid"
+      "disarm_code_invalid": "Disarm code can only contain digits"
     }
   },
   "device_automation": {

--- a/custom_components/vivint/translations/en.json
+++ b/custom_components/vivint/translations/en.json
@@ -46,7 +46,7 @@
       }
     },
     "error": {
-      "disarm_code_invalid": "Disarm code is invalid"
+      "disarm_code_invalid": "Disarm code can only contain digits"
     }
   },
   "device_automation": {


### PR DESCRIPTION
Closes #203 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Disarm code input field now renders as a password input
  * Invalid disarm code error messages now specify that only digits are allowed, providing clearer user guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->